### PR TITLE
Add key bindings

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -30,12 +30,13 @@ bindkey "^A" beginning-of-line
 bindkey "^E" end-of-line
 bindkey "^[B" backward-word
 bindkey "^[b" backward-word
-bindkey "^[[1;5D" backward-word
+bindkey "^[[1;5D" backward-word # WSL
 bindkey "^[F" forward-word
 bindkey "^[f" forward-word
-bindkey "^[[1;5C" forward-word
+bindkey "^[[1;5C" forward-word # WSL
 bindkey "^[D" kill-word
 bindkey "^[d" kill-word
+bindkey "^H" backward-kill-word # WSL
 
 # zsh-autosuggestions
 export ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=100

--- a/zshrc
+++ b/zshrc
@@ -30,8 +30,10 @@ bindkey "^A" beginning-of-line
 bindkey "^E" end-of-line
 bindkey "^[B" backward-word
 bindkey "^[b" backward-word
+bindkey "^[[1;5D" backward-word
 bindkey "^[F" forward-word
 bindkey "^[f" forward-word
+bindkey "^[[1;5C" forward-word
 bindkey "^[D" kill-word
 bindkey "^[d" kill-word
 

--- a/zshrc
+++ b/zshrc
@@ -25,6 +25,16 @@ fi
 autoload -U select-word-style
 select-word-style bash
 
+# Key bindings
+bindkey "^A" beginning-of-line
+bindkey "^E" end-of-line
+bindkey "^[B" backward-word
+bindkey "^[b" backward-word
+bindkey "^[F" forward-word
+bindkey "^[f" forward-word
+bindkey "^[D" kill-word
+bindkey "^[d" kill-word
+
 # zsh-autosuggestions
 export ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE=100
 source "$scriptpath/modules/zsh-autosuggestions/zsh-autosuggestions.zsh"


### PR DESCRIPTION
Key bindings don't seem to be set by default on all machines. On the MacBooks I've worked on they worked out of the box. But on some Linux VMs over SSH they didn't exist. And I think on WSL some may be missing, too.